### PR TITLE
한글의 마지막 글자가 받침을 가지고 있는지 확인하는 함수 추가

### DIFF
--- a/lib/utils/hasJongSeong.ts
+++ b/lib/utils/hasJongSeong.ts
@@ -1,0 +1,14 @@
+function hasJongSeong(hangeul: string) {
+  const unicode = hangeul.charCodeAt(hangeul.length - 1);
+
+  const hangeulStart = 0xac00;
+  const hangeulEnd = 0xd7a3;
+
+  if (unicode < hangeulStart || unicode > hangeulEnd) {
+    return false;
+  }
+
+  return (unicode - hangeulStart) % 28 > 0;
+}
+
+export default hasJongSeong;


### PR DESCRIPTION
README.md의 예시 gif를 봤을 때 클러스터'가'가 아니고 클러스터'이'라고 표시되는 문제를 확인했기 위해 한글의 마지막 글자가 받침을 가지고 있는지 확인하는 함수를 한 번 추가해보았습니다!